### PR TITLE
Fix voting topic console noise on cold loads

### DIFF
--- a/docs/plans/2026-05-13-voting-data-fetch-guard-design.md
+++ b/docs/plans/2026-05-13-voting-data-fetch-guard-design.md
@@ -1,0 +1,49 @@
+# Skip Voting Data Fetch Without an Address — Design
+
+*Date: 2026-05-13*
+*Branch: `fix/voting-data-fetch`*
+
+## Problem
+
+Loading `atlas.phila.gov/voting` cold (no address in URL) runs `VotingStore.fillAllVotingData()`, which calls four `fillX` functions in parallel. Each reads `GeocodeStore.aisData.features[0].geometry.coordinates` directly — with no AIS data, that throws on undefined, gets silently caught, and logs the misleading `"fillDivisions - await never resolved, failed to fetch data"` line (and three siblings). No HTTP calls happen, but the console fills with noise.
+
+## Why only voting
+
+The router's `/:addressOrTopic` route ([router/index.js:316](../../src/router/index.js#L316)) whitelists `['voting']` as the only single-segment URL treated as a topic. Everything else (`/property`, `/li`, etc.) gets routed through the search flow. So voting is the only topic that reaches `topicDataFetch` without an address.
+
+## Fix
+
+Add a two-line guard at the top of [VotingStore.fillAllVotingData](../../src/stores/VotingStore.js#L18):
+
+```js
+async fillAllVotingData() {
+  const GeocodeStore = useGeocodeStore();
+  if (!GeocodeStore.aisData.features) return;
+  this.fillDivisions();
+  this.fillPollingPlaces();
+  this.fillElectedOfficials();
+  this.fillElectionSplit();
+},
+```
+
+This mirrors the established pattern in [CondosStore.fillCondoData:27-28](../../src/stores/CondosStore.js#L27-L28), which already guards itself the same way.
+
+## Why this place
+
+- The store owns its dependency on AIS data — guard belongs next to the dependency.
+- Any future `fillX` added to `fillAllVotingData` is automatically protected.
+- No router changes needed; `dataFetch` stays generic.
+
+## Out of scope
+
+- The four `fillX` functions' misleading `"await never resolved"` catch log. The catch fires on a TypeError, not a fetch rejection. Renaming it is a separate cleanup; with this guard the catches don't trigger anymore.
+- A router-level guard for "no address but on a topic route." Only `voting` reaches this state today, so the per-store fix is sufficient.
+- Resetting `loadingVotingData` for the bailed case. [TopicPanel.vue:55](../../src/components/TopicPanel.vue#L55) renders `VotingIntro` (not `Voting.vue`) when the route is a topic without an address, so the stuck `loadingVotingData = true` is never observed by users.
+
+## Test plan
+
+Manual browser verification:
+
+1. Load `/voting` cold — console no longer shows the four `fillDivisions`/`fillPollingPlaces`/`fillElectedOfficials`/`fillElectionSplit` lines.
+2. From there, search a real address → `/[address]/voting` — polling place tables populate normally (regression check).
+3. Direct load of `/[address]/voting` — same regression check from a cold start.

--- a/docs/plans/2026-05-13-voting-data-fetch-guard-plan.md
+++ b/docs/plans/2026-05-13-voting-data-fetch-guard-plan.md
@@ -1,0 +1,97 @@
+# Voting Data-Fetch Guard Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Stop `VotingStore.fillAllVotingData()` from running its four `fillX` helpers when there is no AIS data yet (i.e. cold load of `/voting`).
+
+**Architecture:** Two-line guard at the top of `fillAllVotingData`, mirroring the pattern already in [CondosStore.fillCondoData:27-28](../../src/stores/CondosStore.js#L27-L28). The store owns its dependency on AIS data; the guard lives next to the dependency.
+
+**Tech Stack:** Pinia store action (Vue 3, plain JS).
+
+**Spec:** [docs/plans/2026-05-13-voting-data-fetch-guard-design.md](./2026-05-13-voting-data-fetch-guard-design.md)
+
+---
+
+## File Structure
+
+- **Modify** `src/stores/VotingStore.js` — add a guard to `fillAllVotingData`. No other files changed.
+
+No tests added. Atlas has no unit-test infrastructure (no `@vue/test-utils`, no Pinia testing rig). Existing tests are live-API integration only (`src/stores/DorStore.test.js`, etc.) and a guard for `if (!features) return` isn't meaningful to test that way. Manual browser verification is the right tool here, matching how `CondosStore`'s identical pattern was verified.
+
+---
+
+### Task 1: Add the address guard to `fillAllVotingData`
+
+**Files:**
+- Modify: `src/stores/VotingStore.js:18-24`
+
+- [ ] **Step 1: Apply the edit**
+
+Open `c:\Users\andy.rothwell\Projects\vue3-atlas\src\stores\VotingStore.js`. The current `fillAllVotingData` action (lines 18–24) is:
+
+```js
+    async fillAllVotingData() {
+      this.fillDivisions();
+      this.fillPollingPlaces();
+      this.fillElectedOfficials();
+      this.fillElectionSplit();
+      // this.fillNextElection();
+    },
+```
+
+Replace with:
+
+```js
+    async fillAllVotingData() {
+      const GeocodeStore = useGeocodeStore();
+      if (!GeocodeStore.aisData.features) return;
+      this.fillDivisions();
+      this.fillPollingPlaces();
+      this.fillElectedOfficials();
+      this.fillElectionSplit();
+      // this.fillNextElection();
+    },
+```
+
+The `useGeocodeStore` import already exists at line 4 of the file — no new import needed.
+
+- [ ] **Step 2: Manual browser verification (Andy)**
+
+Andy runs the dev server. Verify in a browser:
+
+1. Load `atlas.phila.gov/voting` cold (clear console first) → confirm the console no longer shows the four `fillDivisions - await never resolved, failed to fetch data` / `fillPollingPlaces - …` / `fillElectedOfficials - …` / `fillElectionSplit - …` lines.
+2. From `/voting`, search a real address in the search bar → routes to `/[address]/voting` → the polling place / divisions / elected officials / election split tables populate normally (regression check).
+3. Direct-load `/[address]/voting` (a known good address) from a fresh tab → same data populates correctly.
+
+If any of these fail, stop and report what you see.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add src/stores/VotingStore.js
+git commit -m "fix: skip voting data fetch when no address is loaded"
+```
+
+---
+
+### Task 2: Update local handoff
+
+**Files:**
+- Modify: `.claude/handoff.md` (gitignored — local-only update, no commit)
+
+- [ ] **Step 1: Refresh the handoff**
+
+Update `c:\Users\andy.rothwell\Projects\vue3-atlas\.claude\handoff.md` to reflect the completed voting-data-fetch fix and current branch state (`fix/voting-data-fetch`, PR pending). The file is in `.gitignore` so it is NOT committed.
+
+---
+
+## Self-Review
+
+**1. Spec coverage:**
+- Spec's "Fix" section (two-line guard at top of `fillAllVotingData`) → Task 1 Step 1 ✓
+- Spec's "Test plan" (three manual verification steps) → Task 1 Step 2 ✓
+- Spec's "Out of scope" items (catch log rename, router-level guard, loading-flag reset) → no tasks for any of them ✓
+
+**2. Placeholder scan:** No TBDs, no "handle edge cases", no "implement later". The code change is shown in full.
+
+**3. Type consistency:** The composable returns nothing new; the guard touches one Pinia store action. No type or signature drift.

--- a/src/components/topics/Voting.vue
+++ b/src/components/topics/Voting.vue
@@ -200,10 +200,13 @@ const electionTypes = {
 }
 
 const electionDate = computed(() => {
-  if (electionSplit.value) {
-    return formatInTimeZone(electionSplit.value[fieldNames.election_date], 'America/New_York', 'MMMM d, yyyy');
+  const date = electionSplit.value?.[fieldNames.election_date];
+  if (!date) return '';
+  try {
+    return formatInTimeZone(date, 'America/New_York', 'MMMM d, yyyy');
+  } catch {
+    return '';
   }
-  return '';
 });
 
 </script>

--- a/src/main.js
+++ b/src/main.js
@@ -105,7 +105,8 @@ const i18n = createI18n({
   legacy: false,
   locale: 'en-US',
   fallbackLocale: 'en-US',
-  messages: messages
+  messages: messages,
+  warnHtmlMessage: false,
 })
 
 app.use(i18n)

--- a/src/stores/VotingStore.js
+++ b/src/stores/VotingStore.js
@@ -16,6 +16,8 @@ export const useVotingStore = defineStore("VotingStore", {
   },
   actions: {
     async fillAllVotingData() {
+      const GeocodeStore = useGeocodeStore();
+      if (!GeocodeStore.aisData.features) return;
       this.fillDivisions();
       this.fillPollingPlaces();
       this.fillElectedOfficials();


### PR DESCRIPTION
## Summary
- Stops `VotingStore.fillAllVotingData()` from running its four `fillX` helpers when there is no AIS data yet, mirroring the existing guard in `CondosStore.fillCondoData`. Only `voting` reaches this state (it is the only topic whitelisted as a no-address route in the router).
- Silences intlify's `"Detected HTML in '...' message"` warning globally. Atlas's i18n strings deliberately contain HTML rendered via `v-html` — this is the codebase's established pattern. The warning was firing 3+ times on every voting topic load.
- Guards the `electionDate` computed in `Voting.vue` so a missing or malformed `election_date` returns `''` instead of throwing `RangeError: Invalid time value` (which previously cascaded into a Vue render error and broke the whole Voting topic component).

## Design + plan
- `docs/plans/2026-05-13-voting-data-fetch-guard-design.md`
- `docs/plans/2026-05-13-voting-data-fetch-guard-plan.md`

## Test plan
- [x] `/voting` cold load — console no longer shows the four `fillDivisions / fillPollingPlaces / fillElectedOfficials / fillElectionSplit` "await never resolved" lines
- [x] `/[address]/voting` direct load — polling place / divisions / elected officials / election split tables populate correctly; no intlify warnings; no RangeError; no Vue render errors
- [x] Search from `/voting` → `/[address]/voting` — same regression check

## Out of scope
- The misleading `"await never resolved"` catch logs in `VotingStore.js` (the catches fire on TypeErrors, not fetch rejections). The guard prevents them from triggering in the no-address case; rewording is a separate cleanup.
- A router-level guard for "topic without an address." Only `voting` reaches this state today; per-store fix is sufficient.

🤖 Generated with [Claude Code](https://claude.com/claude-code)