### PR TITLE
fix: AIS autocomplete suggestions on mobile keyboards

### DIFF
--- a/.github/workflows/dev_push_to_s3_dev2.yml
+++ b/.github/workflows/dev_push_to_s3_dev2.yml
@@ -6,7 +6,7 @@ name: dev Push to S3 dev2 bucket
 on:
   push:
     branches:
-      - fix/zoning-slider-rollback
+      - fix/autocomplete-on-phone
 jobs:
   build:
 

--- a/src/components/AddressSearchControl.vue
+++ b/src/components/AddressSearchControl.vue
@@ -115,11 +115,12 @@ onBeforeUnmount(() => {
           <input
             :id="inputId"
             ref="inputRef"
-            v-model="MainStore.addressSearchValue"
+            :value="MainStore.addressSearchValue"
             class="input address-input"
             type="text"
             placeholder="Search for an address, OPA account, or DOR number"
             autocomplete="off"
+            @input="MainStore.addressSearchValue = $event.target.value"
             @keydown.enter="replaceRoute(MainStore.addressSearchValue)"
             @keydown="onInputKeydown"
           >


### PR DESCRIPTION
## Summary
- On mobile (confirmed Android Gboard; same pattern on some iOS configs), typing in the address search bar produced no suggestions until the user pressed space or dismissed the keyboard.
- Root cause: Vue's `v-model` on a text input deliberately ignores `input` events while the input is composing (`composing=true`). Mobile keyboards like Gboard treat each word as a composition, so `MainStore.addressSearchValue` never updated mid-word, the watcher in `useSearchSuggestions` never fired, and no fetch happened.
- Fix: swap `v-model` for `:value` + a raw `@input` listener on the input in `AddressSearchControl.vue`. The raw listener fires on every native `input` event regardless of composition state. Desktop behavior is unchanged.

The `chore:` commit on this branch just updates the dev2 deploy trigger to this branch name — leaving it in since that file always points at whatever branch is being tested.

## Test plan
- [x] Desktop: type in the search bar, suggestions appear as before, keyboard/mouse selection works
- [x] Android phone: type "1234 mar" — suggestions appear as the user types, no space-bar required
- [ ] Optional: verify on iOS Safari with predictive text enabled

🤖 Generated with [Claude Code](https://claude.com/claude-code)